### PR TITLE
check errors from close, init go.mod, and add MustGetPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-FreePort
-========
+# FreePort
 
 Get a free open TCP port that is ready to use.
 
 ## Command Line Example:
+
 ```bash
 # Ask the kernel to give us an open port.
 export port=$(freeport)
@@ -16,43 +16,61 @@ curl localhost:$port
 ```
 
 ## Golang example:
+
 ```go
 package main
 
 import "github.com/phayes/freeport"
 
 func main() {
+	// Get one port
 	port, err := freeport.GetFreePort()
 	if err != nil {
 		log.Fatal(err)
 	}
-	// port is ready to listen on
-}
 
+	// Get one port or panic
+	port = freeport.MustGetFreePort()
+
+	// Get n ports
+	ports, err = freeport.GetFreePorts(10)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// usage
+	listener, err := net.Listen(`tcp`, fmt.Sprintf(`localhost:%d`, port))
+
+	// ...
+}
 ```
 
 ## Installation
 
+#### go install from source
+
+- go is required
+
+```bash
+go install github.com/phayes/freeport/cmd/freeport@latest
+```
+
 #### Mac OSX
+
 ```bash
 brew install phayes/repo/freeport
 ```
 
-
 #### CentOS and other RPM based systems
+
 ```bash
 wget https://github.com/phayes/freeport/releases/download/1.0.2/freeport_1.0.2_linux_386.rpm
 rpm -Uvh freeport_1.0.2_linux_386.rpm
 ```
 
 #### Ubuntu and other DEB based systems
+
 ```bash
 wget wget https://github.com/phayes/freeport/releases/download/1.0.2/freeport_1.0.2_linux_amd64.deb
 dpkg -i freeport_1.0.2_linux_amd64.deb
-```
-
-#### Building From Source
-```bash
-sudo apt-get install golang                    # Download go. Alternativly build from source: https://golang.org/doc/install/source
-go get github.com/phayes/freeport
 ```

--- a/cmd/freeport/main.go
+++ b/cmd/freeport/main.go
@@ -11,7 +11,8 @@ import (
 func main() {
 	port, err := freeport.GetFreePort()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf(`unable to get free port: %v`, err)
 	}
-	fmt.Println(strconv.Itoa(port))
+
+	fmt.Print(strconv.Itoa(port))
 }

--- a/freeport_test.go
+++ b/freeport_test.go
@@ -24,7 +24,7 @@ func TestGetFreePort(t *testing.T) {
 }
 
 func TestGetFreePorts(t *testing.T) {
-	count := 3
+	count := 100
 	ports, err := GetFreePorts(count)
 	if err != nil {
 		t.Error(err)
@@ -44,4 +44,28 @@ func TestGetFreePorts(t *testing.T) {
 		}
 		defer l.Close()
 	}
+}
+
+func TestMustGetFreePort(t *testing.T) {
+	func() {
+		defer func() {
+			v := recover()
+			if v != nil {
+				t.Errorf(`panic: %v`, v)
+			}
+		}()
+
+		port := MustGetFreePort()
+
+		if port == 0 {
+			t.Error("port == 0")
+		}
+
+		// Try to listen on the port
+		l, err := net.Listen("tcp", "localhost"+":"+strconv.Itoa(port))
+		if err != nil {
+			t.Error(err)
+		}
+		defer l.Close()
+	}()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/phayes/freeport
+
+go 1.11


### PR DESCRIPTION
- errors from close are not currently checked even though closing the listener is a key step to freeing the port again.
- GetPort being deprecated I find silly since we don't usually expect an error, added a Must* alias
- Simplified the whole double step with ResolveTCP and ListenTCP with simple Listen
- Added entry for simple go install which is standard way to install a go binary for everybody who has go
- Added a go.mod file
- Reformatted markdown file to adhere to standard
- Wrap error messages
- refactor, removing code duplication and pre-allocating known-size slices
- remove unnecessary newline at the end of output in main.go, leading to potential problems

Copied from: https://github.com/phayes/freeport/pull/13